### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
  
   <!-- Component Version Properties -->
   <properties>
-    <spring.version>3.2.15.RELEASE</spring.version>
-    <fileupload.version>1.3.2</fileupload.version>
-    <mysql.version>5.1.35</mysql.version>
+    <spring.version>6.0.18</spring.version>
+    <fileupload.version>1.5</fileupload.version>
+    <mysql.version>8.0.28</mysql.version>
   </properties>
   
   <!-- Dependencies begin here -->
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.4.2</version>
+      <version>2.8.6</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
@@ -82,7 +82,7 @@
       <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.2</version>
+      <version>2.13.4.1</version>
     </dependency>
 	  
  


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 3.2.15.RELEASE | 6.0.18 | No |
| MAVEN | `org.springframework:spring-core` | 3.2.15.RELEASE | 5.2.18.RELEASE | No |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.5 | No |
| MAVEN | `org.springframework:spring-webmvc` | 3.2.15.RELEASE | 4.3.20.RELEASE | No |
| MAVEN | `org.springframework:spring-context` | 3.2.15.RELEASE | 5.2.21.RELEASE | Yes |
| MAVEN | `com.fasterxml.jackson.core:jackson-databind` | 2.4.2 | 2.13.4.1 | No |
| MAVEN | `com.fasterxml.jackson.core:jackson-core` | 2.4.2 | 2.8.6 | No |
| MAVEN | `mysql:mysql-connector-java` | 5.1.35 | 8.0.28 | Yes |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/500tNARA/scans/63577551).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-1c3c00a7687e0eb226b6de4468b29b620d4b7fe7cebef3856c2255ac9abb779b -->
